### PR TITLE
Return output instead of printing.

### DIFF
--- a/Datatables.php
+++ b/Datatables.php
@@ -56,7 +56,7 @@ class Datatables
 		$this->init_columns();
 		$this->regulate_array();
 
-		$this->output();
+		return $this->output();
 	}
 
 
@@ -476,6 +476,6 @@ class Datatables
 		if(Config::get('application.profiler', false)) {
 			Log::write('$this->result_array', '<pre>'.print_r($this->result_array, true).'</pre>');
 		}
-		echo Response::json($output);
+		return Response::json($output);
 	}
 }


### PR DESCRIPTION
Developer can decide what to do with the data, when using bundle in layout enabled controller, either we have to exit after calling the methods or return null; if library return the output, it can be returned to the browser directly.
return Datatables::of($contacts)->make();
