### PR TITLE
Fix the incorrect entries number when filtering

### DIFF
--- a/Datatables.php
+++ b/Datatables.php
@@ -88,11 +88,10 @@ class Datatables
 
 	private function init()
 	{
+		$this->filtering();
 		$this->count();
 		$this->paging();
 		$this->ordering();
-		$this->filtering();
-
 	}
 
 


### PR DESCRIPTION
When filtering, the entries (Showing 1 to 10 of 1,000 entries) are not updated with the correct number of records retrieved and obviously the paging display the incorrect number of pages.
